### PR TITLE
Improve installer reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+installer_state.json
+installer.log

--- a/README.md
+++ b/README.md
@@ -8,4 +8,5 @@ An all-in-one Python-based installer for C/S new hire computers
 1. Place any installation executables in the `installers` folder.
 2. Run `python installer.py` from an elevated PowerShell or Command Prompt. The script will request administrator rights if not already elevated.
 3. The program logs progress to `installer.log` and the console. If `tqdm` is installed, a progress bar is shown for installer files.
-4. If a reboot is required, the machine will restart and continue from the last completed step using the `ShotgunInstallerResume` scheduled task.
+4. `.msi` packages are installed silently via `msiexec /qn /norestart` while other executables are run directly.
+5. If a reboot is required, the machine will restart and continue from the last completed step using the `ShotgunInstallerResume` scheduled task.


### PR DESCRIPTION
## Summary
- handle MSI installers through `msiexec /qn /norestart`
- skip directories when running installers
- remove resume task on fatal errors
- install command now reboots via `shutdown` without shell
- document MSI support in README
- ignore generated state and cache files
- drop corrupt installer_state.json if it cannot be parsed

## Testing
- `flake8 installer.py`
- `python -m py_compile installer.py`
- `python installer.py` *(fails: This installer only runs on Windows)*

------
https://chatgpt.com/codex/tasks/task_e_6862f7564d048330b19d92185225b425