### PR TITLE
Add configurable installer commands

### DIFF
--- a/installers/config.json
+++ b/installers/config.json
@@ -1,0 +1,8 @@
+{
+    ".exe": ["{path}", "/S"],
+    ".msi": ["msiexec", "/i", "{path}", "/qn", "/norestart"],
+    ".msu": ["wusa", "{path}", "/quiet", "/norestart"],
+    ".bat": ["powershell", "-ExecutionPolicy", "Bypass", "-File", "{path}"],
+    ".cmd": ["powershell", "-ExecutionPolicy", "Bypass", "-File", "{path}"],
+    ".ps1": ["powershell", "-ExecutionPolicy", "Bypass", "-File", "{path}"]
+}


### PR DESCRIPTION
## Summary
- allow custom installer commands via `installers/config.json`
- load installer command templates and merge with defaults
- use config in `_run_installer_file`
- document all functions

## Testing
- `flake8 .`
- `pytest -q`
- `mypy installer.py OOBE.py` *(fails: Library stubs not installed for pyautogui, tqdm; attribute errors for winreg)*
- `bandit -r . -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6863fcc2ac188330b65bf442de90f489