### PR TITLE
Add workflow to build Windows executables

### DIFF
--- a/.github/workflows/build_exe.yml
+++ b/.github/workflows/build_exe.yml
@@ -1,0 +1,38 @@
+name: Build EXE
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install pyinstaller pyautogui tqdm
+
+      - name: Build installer executable
+        run: pyinstaller --onefile --noconfirm installer.py
+
+      - name: Build OOBE executable
+        run: pyinstaller --onefile --noconfirm OOBE.py
+
+      - name: Upload executables
+        uses: actions/upload-artifact@v4
+        with:
+          name: executables
+          path: |
+            dist/installer.exe
+            dist/OOBE.exe
+


### PR DESCRIPTION
## Summary
- automate building `.exe` files using PyInstaller on Windows runners

## Testing
- `python -m py_compile installer.py OOBE.py`

------
https://chatgpt.com/codex/tasks/task_e_6864589084f48330ba18d589a8803096