### PR TITLE
Improve installation utilities

### DIFF
--- a/OOBE.py
+++ b/OOBE.py
@@ -1,9 +1,10 @@
 """Automate the Windows OOBE bypass shortcut.
 
 This script presses ``Shift+F10`` to open a command prompt and then types the
-command ``OOBE/bypassnro``. It exits early if executed on a non-Windows system
-or if ``pyautogui`` cannot be imported (such as when no graphical environment
-is available).
+command ``OOBE/bypassnro``. It exits early if executed on a non-Windows
+system or if ``pyautogui`` cannot be imported (such as when no graphical
+environment is available). Use ``--dry-run`` to log actions without sending
+keyboard input.
 """
 
 import argparse
@@ -11,37 +12,46 @@ import sys
 import time
 import logging
 import platform
+import os
 
 try:
     import pyautogui
-except Exception as exc:  # pragma: no cover - environment specific
-    print(
-        f'Failed to import pyautogui: {exc}. '
-        'Please ensure the library is installed and '
-        'a graphical environment is available.'
+except ImportError as exc:  # pragma: no cover - environment specific
+    msg = [f"Failed to import pyautogui: {exc}"]
+    if os.name != "nt" and "DISPLAY" not in os.environ:
+        msg.append("DISPLAY environment variable is not set")
+    msg.append(
+        "Please ensure the library is installed and a graphical environment is available."
     )
+    print(". ".join(msg))
     sys.exit(1)
 
 pyautogui.FAILSAFE = False
 pyautogui.PAUSE = 0.1
 
 
-def open_command_prompt(delay: float = 2.0) -> None:
+def open_command_prompt(delay: float = 2.0, *, dry_run: bool = False) -> None:
     """Open a command prompt via the Shift+F10 hotkey."""
-    pyautogui.hotkey('shift', 'f10')
+    if dry_run:
+        logger.info("[DRY RUN] Would press Shift+F10")
+    else:
+        pyautogui.hotkey("shift", "f10")
     time.sleep(delay)
 
 
-def type_command(command: str) -> None:
+def type_command(command: str, *, dry_run: bool = False) -> None:
     """Type a command and press Enter."""
-    pyautogui.typewrite(command)
-    pyautogui.press('enter')
+    if dry_run:
+        logger.info("[DRY RUN] Would type: %s", command)
+    else:
+        pyautogui.typewrite(command)
+        pyautogui.press("enter")
 
 
 logging.basicConfig(
     level=logging.DEBUG,
-    format='%(asctime)s [%(levelname)s] %(message)s',
-    handlers=[logging.StreamHandler(sys.stdout)]
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
 logger = logging.getLogger(__name__)
 
@@ -52,31 +62,36 @@ def main(argv: list[str] | None = None) -> None:
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        '--delay',
+        "--delay",
         type=float,
         default=2.0,
-        help='Delay in seconds after opening the command prompt',
+        help="Delay in seconds after opening the command prompt",
     )
     parser.add_argument(
-        'command',
-        nargs='?',
-        default='OOBE/bypassnro',
-        help='Command to execute after the command prompt opens',
+        "--dry-run",
+        action="store_true",
+        help="Log actions without sending any keyboard input",
+    )
+    parser.add_argument(
+        "command",
+        nargs="?",
+        default="OOBE/bypassnro",
+        help="Command to execute after the command prompt opens",
     )
     args = parser.parse_args(argv)
 
-    if platform.system() != 'Windows':
-        logger.error('This script is intended to run on Windows.')
-        return
+    if platform.system() != "Windows":
+        logger.error("This script is intended to run on Windows.")
+        sys.exit(1)
 
-    logger.info('Opening command prompt with Shift+F10')
+    logger.info("Opening command prompt with Shift+F10")
     try:
-        open_command_prompt(args.delay)
-        logger.info('Typing command: %s', args.command)
-        type_command(args.command)
-    except Exception as exc:
-        logger.exception('Automation failed: %s', exc)
+        open_command_prompt(args.delay, dry_run=args.dry_run)
+        logger.info("Typing command: %s", args.command)
+        type_command(args.command, dry_run=args.dry_run)
+    except (pyautogui.FailSafeException, pyautogui.PyAutoGUIException) as exc:
+        logger.exception("Automation failed: %s", exc)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ An all-in-one Python-based installer for C/S new hire computers
 2. The program logs progress to `installer.log` and the console.
 3. If a reboot is required, the machine will restart and continue from the last completed step using the `ShotgunInstallerResume` scheduled task.
 4. After updates finish, a pop-up confirms completion before proceeding.
+5. To resume manually after an unexpected reboot, rerun `python installer.py`
+   The script continues from the saved step in `installer_state.json`.
+6. Use `--windows-updates` and `--dell-updates` to run only selected steps.
 
 ## Windows OOBE Bypass Utility
 
@@ -16,9 +19,10 @@ An all-in-one Python-based installer for C/S new hire computers
 
 ### Usage
 ```bash
-python OOBE.py [--delay SECONDS] [command]
+python OOBE.py [--delay SECONDS] [--dry-run] [command]
 ```
 - `--delay` specifies how long to wait after the command prompt opens (default 2 seconds).
+- `--dry-run` logs actions without sending any keyboard input.
 - `command` is the command to run once the prompt appears; the default is `OOBE/bypassnro`.
 
 The script exits early on non-Windows systems or if `pyautogui` cannot be loaded.

--- a/installer.py
+++ b/installer.py
@@ -6,53 +6,67 @@ import logging
 import subprocess
 import ctypes
 import platform
-import os
 import urllib.request
+import urllib.error
 import re
 import tempfile
+import argparse
+import socket
+
+try:
+    import winreg
+except ImportError:  # pragma: no cover - non-Windows systems
+    winreg = None
 from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent
 
 
-
-STATE_FILE = BASE_DIR / 'installer_state.json'
-LOG_FILE = BASE_DIR / 'installer.log'
-SCHEDULED_TASK_NAME = 'ShotgunInstallerResume'
-
+STATE_FILE = BASE_DIR / "installer_state.json"
+LOG_FILE = BASE_DIR / "installer.log"
+SCHEDULED_TASK_NAME = "ShotgunInstallerResume"
 
 
 logging.basicConfig(
     level=logging.DEBUG,
-    format='%(asctime)s [%(levelname)s] %(message)s',
+    format="%(asctime)s [%(levelname)s] %(message)s",
     handlers=[
-        logging.FileHandler(LOG_FILE, mode='a', encoding='utf-8'),
-        logging.StreamHandler(sys.stdout)
-    ]
+        logging.FileHandler(LOG_FILE, mode="a", encoding="utf-8"),
+        logging.StreamHandler(sys.stdout),
+    ],
 )
 logger = logging.getLogger(__name__)
+
+
+def has_network(host: str = "dell.com", port: int = 443, timeout: float = 5.0) -> bool:
+    """Return ``True`` if a TCP connection to the given host succeeds."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
 
 
 def is_admin() -> bool:
     """Return ``True`` if running with administrator privileges."""
 
-    if platform.system() != 'Windows':
+    if platform.system() != "Windows":
         return False
     try:
         return ctypes.windll.shell32.IsUserAnAdmin()
-    except Exception as e:
-        logger.error('Admin check failed: %s', e)
+    except OSError as e:
+        logger.error("Admin check failed: %s", e)
         return False
 
 
 def run_as_admin() -> None:
     """Re-launch this script with administrator rights and exit."""
-    logger.info('Re-launching script with administrator privileges')
+    logger.info("Re-launching script with administrator privileges")
     script = Path(__file__).resolve()
-    params = ' '.join([f'"{script}"'] + [f'"{p}"' for p in sys.argv[1:]])
+    params = subprocess.list2cmdline([str(script)] + sys.argv[1:])
     ctypes.windll.shell32.ShellExecuteW(
         None,
-        'runas',
+        "runas",
         sys.executable,
         params,
         str(BASE_DIR),
@@ -65,21 +79,33 @@ def load_state() -> dict:
     """Return persisted install state or an empty default."""
     if STATE_FILE.exists():
         try:
-            with STATE_FILE.open('r', encoding='utf-8') as f:
-                return json.load(f)
-        except json.JSONDecodeError:
-            logger.warning('State file corrupt, removing and starting fresh')
+            with STATE_FILE.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            if (
+                isinstance(data, dict)
+                and "step" in data
+                and isinstance(data["step"], int)
+            ):
+                return data
+            logger.warning("State file invalid, starting fresh")
             try:
                 STATE_FILE.unlink()
             except OSError as e:
-                logger.error('Failed to delete corrupt state file: %s', e)
-    return {'step': 0}
+                logger.error("Failed to delete invalid state file: %s", e)
+        except json.JSONDecodeError:
+            logger.warning("State file corrupt, removing and starting fresh")
+            try:
+                STATE_FILE.unlink()
+            except OSError as e:
+                logger.error("Failed to delete corrupt state file: %s", e)
+    return {"step": 0}
 
 
 def save_state(state: dict) -> None:
     """Persist installer progress to the state file."""
-    with STATE_FILE.open('w', encoding='utf-8') as f:
+    with STATE_FILE.open("w", encoding="utf-8") as f:
         json.dump(state, f)
+
 
 # --- Restart handling ---
 
@@ -87,77 +113,84 @@ def save_state(state: dict) -> None:
 def create_resume_task() -> None:
     """Create a scheduled task to resume this installer after reboot."""
     cmd = [
-        'schtasks', '/Create', '/F', '/TN', SCHEDULED_TASK_NAME,
-        '/SC', 'ONSTART', '/RL', 'HIGHEST', '/RU', 'SYSTEM',
-        '/TR',
-        ' '.join(
-            f'"{p}"' for p in [sys.executable, Path(__file__).resolve()]
-        ),
+        "schtasks",
+        "/Create",
+        "/F",
+        "/TN",
+        SCHEDULED_TASK_NAME,
+        "/SC",
+        "ONSTART",
+        "/RL",
+        "HIGHEST",
+        "/RU",
+        "SYSTEM",
+        "/TR",
+        " ".join(f'"{p}"' for p in [sys.executable, Path(__file__).resolve()]),
     ]
     try:
         subprocess.run(cmd, check=True)
-        logger.info('Scheduled task for resume created')
-    except Exception as e:
-        logger.error('Failed to create scheduled task: %s', e)
+        logger.info("Scheduled task for resume created")
+    except subprocess.CalledProcessError as e:
+        logger.error("Failed to create scheduled task: %s", e)
 
 
 def remove_resume_task() -> None:
     """Delete the scheduled resume task if it exists."""
-    cmd = ['schtasks', '/Delete', '/F', '/TN', SCHEDULED_TASK_NAME]
+    cmd = ["schtasks", "/Delete", "/F", "/TN", SCHEDULED_TASK_NAME]
     subprocess.run(cmd, check=False)
 
 
 def reboot_system() -> None:
     """Reboot the machine and schedule resume of the installer."""
     create_resume_task()
-    logger.info('Rebooting system...')
-    subprocess.run(['shutdown', '/r', '/t', '5', '/f'], check=True)
+    logger.info("Rebooting system...")
+    subprocess.run(["shutdown", "/r", "/t", "5", "/f"], check=True)
 
 
 def is_reboot_pending() -> bool:
     """Return ``True`` if Windows signals that a reboot is pending."""
     reboot_keys = [
         (
-            r'SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate'
-            r'\Auto Update\RebootRequired'
+            r"SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate"
+            r"\Auto Update\RebootRequired"
         ),
         (
-            r'SYSTEM\CurrentControlSet\Control\Session Manager'
-            r'\PendingFileRenameOperations'
+            r"SYSTEM\CurrentControlSet\Control\Session Manager"
+            r"\PendingFileRenameOperations"
         ),
     ]
-    try:
-        import winreg
-        for subkey in reboot_keys:
-            try:
-                winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, subkey)
-                return True
-            except FileNotFoundError:
-                continue
-    except Exception:
-        logger.debug('winreg not available for reboot check')
+    if winreg is None:
+        logger.debug("winreg not available for reboot check")
+        return False
+    for subkey in reboot_keys:
+        try:
+            winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, subkey)
+            return True
+        except FileNotFoundError:
+            continue
     return False
+
 
 # --- Windows Updates ---
 
 
 def install_windows_updates() -> None:
     """Install all available Windows updates via PowerShell."""
-    logger.info('Installing Windows updates...')
+    logger.info("Installing Windows updates...")
     powershell_cmd = (
-        'Install-Module -Name PSWindowsUpdate -Force; '
-        'Import-Module PSWindowsUpdate; '
-        'Add-WUServiceManager -MicrosoftUpdate; '
-        'Get-WindowsUpdate -Install -AcceptAll -MicrosoftUpdate -IgnoreReboot'
+        "Install-Module -Name PSWindowsUpdate -Force; "
+        "Import-Module PSWindowsUpdate; "
+        "Add-WUServiceManager -MicrosoftUpdate; "
+        "Get-WindowsUpdate -Install -AcceptAll -MicrosoftUpdate -IgnoreReboot"
     )
     try:
         result = subprocess.run(
             [
-                'powershell',
-                '-NoProfile',
-                '-ExecutionPolicy',
-                'Bypass',
-                '-Command',
+                "powershell",
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
                 powershell_cmd,
             ],
             check=False,
@@ -165,110 +198,144 @@ def install_windows_updates() -> None:
             text=True,
         )
         if result.returncode == 0:
-            logger.info('Windows updates installed successfully')
+            logger.info("Windows updates installed successfully")
         else:
             logger.error(
-                'Windows update command failed with code %s', result.returncode
+                "Windows update command failed with code %s", result.returncode
             )
             if result.stdout:
-                logger.error('stdout: %s', result.stdout.strip())
+                logger.error("stdout: %s", result.stdout.strip())
             if result.stderr:
-                logger.error('stderr: %s', result.stderr.strip())
-    except Exception as e:
-        logger.error('Windows update invocation failed: %s', e)
+                logger.error("stderr: %s", result.stderr.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        logger.error("Windows update invocation failed: %s", e)
+
 
 # --- Dell Updates ---
 
 
 def download_latest_dcu() -> Path | None:
     """Download the latest Dell Command Update installer and return its path."""
-    url_page = (
-        'https://www.dell.com/support/kbdoc/en-us/000183146/dell-command-update'
-    )
+    url_page = "https://www.dell.com/support/kbdoc/en-us/000183146/dell-command-update"
     try:
-        with urllib.request.urlopen(url_page) as resp:
-            html = resp.read().decode('utf-8', errors='ignore')
+        req = urllib.request.Request(url_page, headers={"User-Agent": "Mozilla/5.0"})
+        with urllib.request.urlopen(req) as resp:
+            html = resp.read().decode("utf-8", errors="ignore")
         match = re.search(
             r'https://dl\.dell\.com/[^"\s]*Command-Update[^"\s]*\.exe', html
         )
         if not match:
-            logger.error('Could not find Dell Command Update download link')
+            logger.error("Could not find Dell Command Update download link")
             return None
         url = match.group(0)
-        fd, tmp_path = tempfile.mkstemp(suffix='.exe')
-        os.close(fd)
-        logger.info('Downloading Dell Command Update from %s', url)
-        urllib.request.urlretrieve(url, tmp_path)
-        return Path(tmp_path)
-    except Exception as exc:
-        logger.error('Failed to download Dell Command Update: %s', exc)
+        if not has_network():
+            logger.warning("Network unavailable, skipping Dell update download")
+            return None
+        logger.info("Downloading Dell Command Update from %s", url)
+        req_dl = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        with urllib.request.urlopen(req_dl) as resp:
+            total = int(resp.headers.get("Content-Length", "0"))
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".exe") as tmp:
+                downloaded = 0
+                while True:
+                    chunk = resp.read(8192)
+                    if not chunk:
+                        break
+                    tmp.write(chunk)
+                    downloaded += len(chunk)
+                    if total:
+                        percent = downloaded * 100 // total
+                        print(f"\rDownload {percent}% complete", end="", flush=True)
+        print()
+        return Path(tmp.name)
+    except (urllib.error.URLError, OSError) as exc:
+        logger.error("Failed to download Dell Command Update: %s", exc)
         return None
 
 
 def install_dell_updates() -> None:
     """Install firmware and driver updates via Dell Command Update."""
-    logger.info('Installing Dell Command Update updates...')
+    logger.info("Installing Dell Command Update updates...")
+    if not has_network():
+        logger.warning("Network unavailable, skipping Dell updates")
+        return
     candidates = [
-        Path('C:/Program Files/Dell/CommandUpdate/dcu-cli.exe'),
-        Path('C:/Program Files (x86)/Dell/CommandUpdate/dcu-cli.exe'),
+        Path("C:/Program Files/Dell/CommandUpdate/dcu-cli.exe"),
+        Path("C:/Program Files (x86)/Dell/CommandUpdate/dcu-cli.exe"),
     ]
     dcu = next((p for p in candidates if p.exists()), None)
     if not dcu:
-        logger.warning('Dell Command Update executable not found')
+        logger.warning("Dell Command Update executable not found")
         installer = download_latest_dcu()
         if not installer:
-            logger.error('Unable to download Dell Command Update')
+            logger.error("Unable to download Dell Command Update")
             return
         try:
-            subprocess.run([str(installer), '/s'], check=True)
-        except Exception as e:
-            logger.error('Failed to install Dell Command Update: %s', e)
+            subprocess.run([str(installer), "/s"], check=True)
+        except subprocess.CalledProcessError as e:
+            logger.error("Failed to install Dell Command Update: %s", e)
             return
         dcu = next((p for p in candidates if p.exists()), None)
         if not dcu:
-            logger.error('Dell Command Update installation did not create CLI')
+            logger.error("Dell Command Update installation did not create CLI")
             return
     try:
         result = subprocess.run(
-            [str(dcu), '/applyUpdates', '/silent'],
+            [str(dcu), "/applyUpdates", "/silent"],
             check=False,
             capture_output=True,
             text=True,
         )
         if result.returncode == 0:
-            logger.info('Dell Command Update completed successfully')
+            logger.info("Dell Command Update completed successfully")
         elif result.returncode == 2:
-            logger.info('No Dell updates available')
+            logger.info("No Dell updates available")
         elif result.returncode == 102:
-            logger.info('Dell Command Update requires a reboot to continue')
+            logger.info("Dell Command Update requires a reboot to continue")
         else:
             logger.error(
-                'Dell Command Update failed with exit code %s: %s',
+                "Dell Command Update failed with exit code %s: %s",
                 result.returncode,
                 result.stdout.strip() or result.stderr.strip(),
             )
-    except Exception as e:
-        logger.error('Dell Command Update invocation failed: %s', e)
+    except subprocess.CalledProcessError as e:
+        logger.error("Dell Command Update invocation failed: %s", e)
+
 
 # --- Install files ---
 
 
-
-
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
     """Run update and installer steps, handling reboots as needed."""
-    if platform.system() != 'Windows':
-        logger.error('This installer only runs on Windows')
-        return
+    if platform.system() != "Windows":
+        logger.error("This installer only runs on Windows")
+        sys.exit(1)
     if not is_admin():
         run_as_admin()
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--windows-updates", action="store_true", help="run Windows updates"
+    )
+    parser.add_argument(
+        "--dell-updates", action="store_true", help="run Dell Command updates"
+    )
+    args = parser.parse_args(argv)
+
     state = load_state()
-    steps = [install_windows_updates, install_dell_updates]
-    for idx, func in enumerate(steps, start=1):
-        if state['step'] >= idx:
+    steps_all = [install_windows_updates, install_dell_updates]
+    selected_steps = []
+    if args.windows_updates:
+        selected_steps.append(install_windows_updates)
+    if args.dell_updates:
+        selected_steps.append(install_dell_updates)
+    if not selected_steps:
+        selected_steps = steps_all
+    for idx, func in enumerate(selected_steps, start=1):
+        if state["step"] >= idx:
             continue
         func()
-        state['step'] = idx
+        state["step"] = idx
         save_state(state)
         if is_reboot_pending():
             save_state(state)
@@ -279,19 +346,19 @@ def main() -> None:
     try:
         ctypes.windll.user32.MessageBoxW(
             0,
-            'All Windows & Dell Command Updates Finished! Moving to the next phase...',
-            'Updates Complete',
+            "All Windows & Dell Command Updates Finished! Moving to the next phase...",
+            "Updates Complete",
             0x40,
         )
-    except Exception as e:
-        logger.error('Failed to display completion message: %s', e)
-    logger.info('Installation completed successfully')
+    except OSError as e:
+        logger.error("Failed to display completion message: %s", e)
+    logger.info("Installation completed successfully")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     try:
         main()
     except Exception as exc:
-        logger.exception('Fatal error: %s', exc)
+        logger.exception("Fatal error: %s", exc)
         remove_resume_task()
         sys.exit(1)

--- a/post_oobe.py
+++ b/post_oobe.py
@@ -20,7 +20,7 @@ import platform
 import sys
 import time
 
-IS_WINDOWS = platform.system() == 'Windows'
+IS_WINDOWS = platform.system() == "Windows"
 if IS_WINDOWS:
     USER32 = ctypes.windll.user32
 else:
@@ -36,21 +36,38 @@ VK_SHIFT = 0x10
 
 # mapping for simple alphanumeric characters
 CHAR_TO_VK = {
-    **{chr(c): c for c in range(ord('0'), ord('9') + 1)},
-    **{chr(c): c for c in range(ord('A'), ord('Z') + 1)},
-    '-': 0xBD,
+    **{chr(c): c for c in range(ord("0"), ord("9") + 1)},
+    **{chr(c): c for c in range(ord("A"), ord("Z") + 1)},
+    "-": 0xBD,
+    "_": 0xBD,
 }
 
 logging.basicConfig(
     level=logging.DEBUG,
-    format='%(asctime)s [%(levelname)s] %(message)s',
-    handlers=[logging.StreamHandler(sys.stdout)],
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[
+        logging.StreamHandler(sys.stdout),
+        logging.FileHandler("post_oobe.log", mode="a", encoding="utf-8"),
+    ],
 )
 LOGGER = logging.getLogger(__name__)
 
 
+def ensure_oobe_window_foreground() -> None:
+    """Log a warning if the active window does not appear to be OOBE."""
+    if USER32 is None:
+        return
+    hwnd = USER32.GetForegroundWindow()
+    buf = ctypes.create_unicode_buffer(256)
+    USER32.GetWindowTextW(hwnd, buf, 256)
+    title = buf.value.lower()
+    if "out of box experience" not in title:
+        LOGGER.warning("OOBE window not in foreground: %s", buf.value)
+
+
 class KEYBDINPUT(ctypes.Structure):  # pylint: disable=too-few-public-methods
     """Structure passed to ``SendInput`` for keyboard events."""
+
     _fields_ = [
         ("wVk", ctypes.c_ushort),
         ("wScan", ctypes.c_ushort),
@@ -62,6 +79,7 @@ class KEYBDINPUT(ctypes.Structure):  # pylint: disable=too-few-public-methods
 
 class INPUT(ctypes.Structure):  # pylint: disable=too-few-public-methods
     """General input structure for ``SendInput``."""
+
     _fields_ = [
         ("type", ctypes.c_ulong),
         ("ki", KEYBDINPUT),
@@ -75,7 +93,7 @@ def _send_vk(vk: int, flags: int = 0) -> None:
     inp = INPUT(INPUT_KEYBOARD, KEYBDINPUT(vk, 0, flags, 0, None))
     sent = USER32.SendInput(1, ctypes.byref(inp), ctypes.sizeof(inp))
     if sent != 1:
-        LOGGER.warning('SendInput failed for vk=%s flags=%s', vk, flags)
+        LOGGER.warning("SendInput failed for vk=%s flags=%s", vk, flags)
     time.sleep(0.05)
 
 
@@ -91,23 +109,27 @@ def press_key(vk: int, *, shift: bool = False) -> None:
 
 def type_text(text: str) -> None:
     """Type a string using virtual-key codes."""
+    shift_chars = {"_"}
     for ch in text:
         upper = ch.upper()
         vk = CHAR_TO_VK.get(upper)
         if vk is None:
-            LOGGER.warning('Skipping unsupported character: %r', ch)
+            LOGGER.warning("Skipping unsupported character: %r", ch)
             continue
-        press_key(vk, shift=ch.isalpha() and ch.isupper())
+        need_shift = (ch.isalpha() and ch.isupper()) or ch in shift_chars
+        press_key(vk, shift=need_shift)
         time.sleep(0.05)
 
 
 def oobe_flow(device_name: str) -> None:
     """Complete the Windows setup screens using keyboard automation."""
     if not IS_WINDOWS:
-        LOGGER.error('This script is intended for Windows only.')
+        LOGGER.error("This script is intended for Windows only.")
         return
 
-    LOGGER.info('Starting OOBE automation sequence')
+    ensure_oobe_window_foreground()
+
+    LOGGER.info("Starting OOBE automation sequence")
     # region selection (default English)
     press_key(VK_RETURN)
     time.sleep(5)
@@ -128,7 +150,7 @@ def oobe_flow(device_name: str) -> None:
     press_key(VK_RETURN)
     time.sleep(5)
     # stop on device name screen
-    LOGGER.info('Waiting for device name input')
+    LOGGER.info("Waiting for device name input")
     type_text(device_name)
     press_key(VK_RETURN)
     time.sleep(2)
@@ -139,21 +161,21 @@ def oobe_flow(device_name: str) -> None:
     for _ in range(6):
         time.sleep(2)
         press_key(VK_RETURN)
-    LOGGER.info('Automation complete, awaiting desktop')
+    LOGGER.info("Automation complete, awaiting desktop")
     time.sleep(30)
 
 
 def main(argv: list[str] | None = None) -> None:
     """Entry point for command line execution."""
-    parser = argparse.ArgumentParser(description='Automate OOBE after bypass')
-    parser.add_argument('cs_number', help='Numeric identifier for computer')
+    parser = argparse.ArgumentParser(description="Automate OOBE after bypass")
+    parser.add_argument("cs_number", help="Numeric identifier for computer")
     args = parser.parse_args(argv)
     if not args.cs_number.isdigit():
-        parser.error('cs_number must be numeric')
+        parser.error("cs_number must be numeric")
     if not IS_WINDOWS:
-        parser.error('This script only runs on Windows')
-    oobe_flow(f'CS-{args.cs_number}')
+        parser.error("This script only runs on Windows")
+    oobe_flow(f"CS-{args.cs_number}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- format Python files with Black
- add CLI flag documentation and dry-run options to README
- retain detailed error messages and Windows checks for scripts

## Testing
- `pylint OOBE.py post_oobe.py installer.py`
- `python -m py_compile OOBE.py post_oobe.py installer.py`
- `black --check OOBE.py post_oobe.py installer.py`
- `python OOBE.py --dry-run` *(fails: no DISPLAY)*
- `python post_oobe.py 123` *(fails: script only runs on Windows)*
- `python installer.py --windows-updates` *(fails: installer only runs on Windows)*

------
https://chatgpt.com/codex/tasks/task_e_68646bf4ca008330a8193025895b91e5